### PR TITLE
Fixed #22

### DIFF
--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -143,6 +143,11 @@ var StratumClient = function(options, logger){
     }
 
     function handleAuthorize(message, replyToSocket){
+        if (!message.params) {
+            _this.emit('malformedMessage', message);
+            return socket.destroy();
+        }
+
         _this.workerName = message.params[0];
         _this.workerPass = message.params[1];
         options.authorizeFn(_this.remoteAddress, options.socket.localPort, _this.workerName, _this.workerPass, function(result) {
@@ -164,6 +169,11 @@ var StratumClient = function(options, logger){
     }
 
     function handleSubmit(message){
+        if (!message.params) {
+            _this.emit('malformedMessage', message);
+            return socket.destroy();
+        }
+
         if (!_this.authorized){
             sendJson({
                 id    : message.id,


### PR DESCRIPTION
This pull request fixes pool vulnerability described in #22. At first I thought that it's good to check all JSON RPC calls for validity [by specification](http://www.jsonrpc.org/specification), but after some thinking I've came to opinion that it's not necessary in general and I can fix issue's main case by checking that in `message` object necessary key is presented. That will be be less wasteful for performance. 