### PR TITLE
Prevent duplicate share submissions

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -116,7 +116,7 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, pool
     };
 
     this.registerSubmit = function(extraNonce1, extraNonce2, nTime, nonce){
-        var submission = extraNonce1 + extraNonce2 + nTime + nonce;
+        var submission = (extraNonce1 + extraNonce2 + nTime + nonce).toLowerCase();
         if (submits.indexOf(submission) === -1){
             submits.push(submission);
             return true;


### PR DESCRIPTION
Force lowercase on share submission, preventing share to be submitted multiple times by altering caps in the share submission.